### PR TITLE
Fix off by one error in Sophocles

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -27,7 +27,7 @@
               "xml": "sophocles_OT_crasisEtc.xml",
               "link": "https://www.example.com",
               "notes": "Mambrini's work updated with all crasis divided, extra attributes added to give full forms for words altered by crasis, elision etc; minor corrections to relations and postags.",
-              "chunks": { "start": 1, "end": 932 }
+              "chunks": { "start": 1, "end": 931 }
             }
           ]
         }


### PR DESCRIPTION
The last sentence in the XML for Sophocles, *Oedipus Tyrannus* has `id="931"`, but the Treebank Template configuration goes up to 932.

This PR changes the maximum to 931 so that the application doesn't error when navigating through *Oedipus Tyrannus*.

A few of the other treebanks have a maximum chunk less than the XML. I'm not sure if this is intended or not, so I didn't touch them. But it might be worth taking a look!